### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Appcessorize is a simple library that lets users make their photos into phone ca
 
 Installing Appcessorize.framework is a quick and easy process. This may be done manually or via [cocoapods](http://cocoapods.org/)
 
-### Installing via Cocoapods (recommended)
+### Installing via CocoaPods (recommended)
 
 If you have already installed CocoaPods then you can skip this step.
 


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
